### PR TITLE
Fix odd number of elements

### DIFF
--- a/t/release-synopsis.t
+++ b/t/release-synopsis.t
@@ -13,4 +13,4 @@ use Test::More;
 eval "use Test::Synopsis";
 plan skip_all => "Test::Synopsis required for testing synopses"
     if $@;
-all_synopsis_ok('lib');
+all_synopsis_ok();


### PR DESCRIPTION
From Test::Synopsis, all_synopsis_ok() takes zero or two arguments. Two
argument form is a hash that can be: dump_all_code_on_error => [01]. 'lib' is not a valid argument.